### PR TITLE
🐛 musl ビルド時の古い設定ファイルをクリーンアップ

### DIFF
--- a/scripts/build-musl.sh
+++ b/scripts/build-musl.sh
@@ -168,6 +168,13 @@ check_prerequisites() {
 configure_musl() {
     log_build "Configuring musl libc for $ARCH"
 
+    # Clean build directory to avoid stale configuration
+    if [ -d "$MUSL_BUILD_DIR" ]; then
+        log_info "Cleaning stale build directory"
+        rm -rf "$MUSL_BUILD_DIR"
+        mkdir -p "$MUSL_BUILD_DIR"
+    fi
+
     cd "$MUSL_BUILD_DIR" || exit 1
 
     # Security hardening flags


### PR DESCRIPTION
## 概要
ARM64ビルド時に古いARCH値(arm64)を持つMakefileが残っていることで発生するエラーを修正

## 問題
PR #16 でarm64→aarch64の正規化を追加したが、以前のビルドで生成されたMakefileが残っている場合、古いARCH値(arm64)を参照し続ける:

```
make[1]: *** No rule to make target '/build/kimigayo/build/musl-src/musl-1.2.4/arch/arm64/bits/alltypes.h.in'
```

## 原因
- configure実行時にARCHは正しく`aarch64`に正規化される
- しかし、ビルドディレクトリに古いMakefileが残っている場合、それが使われる
- 古いMakefileは`arm64`パスを参照している

## 修正内容
configure前にビルドディレクトリを完全にクリーンアップ:
```bash
if [ -d "$MUSL_BUILD_DIR" ]; then
    log_info "Cleaning stale build directory"
    rm -rf "$MUSL_BUILD_DIR"
    mkdir -p "$MUSL_BUILD_DIR"
fi
```

## テスト
- [ ] CI (ShellCheck, Build) がパス
- [ ] ARM64ビルドが成功することを確認
- [ ] x86_64ビルドが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)