### PR TITLE
🐛 HOTFIX: SCRIPT_DIR変数の未定義エラーを修正

### DIFF
--- a/scripts/build-busybox.sh
+++ b/scripts/build-busybox.sh
@@ -6,8 +6,9 @@
 
 set -euo pipefail
 
-# Save project root directory
-PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Save script and project root directories
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # Configuration
 BUSYBOX_VERSION="${BUSYBOX_VERSION:-1.36.1}"


### PR DESCRIPTION
## 緊急修正（HOTFIX）

PR #38マージ時に混入したバグにより、**全てのビルドが失敗**しています。緊急修正PRです。

## 問題

### エラー内容
```
/build/kimigayo/build-system/../scripts/build-busybox.sh: line 82: SCRIPT_DIR: unbound variable
make: *** [Makefile:210: busybox] Error 1
```

### 影響範囲
- ✅ PR #38マージ後のmainブランチ：**全ビルド失敗**
- ✅ PR #39（VI有効化）：**同じエラーで失敗**
- ❌ CI/CD：全てのビルドジョブが失敗中

### 原因
PR #38でパッチ適用コードを追加した際、`SCRIPT_DIR`変数の定義を追加し忘れました：

```bash
# PR #38で追加されたコード（82行目）
if [ -f "${SCRIPT_DIR}/apply-busybox-patches.sh" ]; then
    log_info "Applying BusyBox patches..."
    bash "${SCRIPT_DIR}/apply-busybox-patches.sh"
fi
```

しかし、`SCRIPT_DIR`変数はスクリプト内で定義されていませんでした。

## 修正内容

### scripts/build-busybox.sh

```diff
 set -euo pipefail
 
-# Save project root directory
-PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Save script and project root directories
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
```

### 変更点
1. `SCRIPT_DIR`変数を追加（スクリプトディレクトリのパス）
2. `PROJECT_ROOT`の定義も`SCRIPT_DIR`を使用するように変更

## テスト

### ローカルテスト
```bash
# 変数が正しく定義されているか確認
bash -c 'source scripts/build-busybox.sh; echo "SCRIPT_DIR=$SCRIPT_DIR"'
# 期待: SCRIPT_DIR=/path/to/Kimigayo/scripts

# パッチ適用パスが正しいか確認
bash -c 'source scripts/build-busybox.sh; ls -l "${SCRIPT_DIR}/apply-busybox-patches.sh"'
# 期待: ファイルが存在する
```

### CI/CDテスト
このPRがマージされると、以下が修正されます：
- ✅ mainブランチのビルドが成功
- ✅ PR #39のビルドも成功（同じ修正を適用済み）

## なぜマージ時に気づかなかったか

PR #38のマージ時、CI/CDが**失敗**していました：
- CI結論: `"conclusion":"failure"`
- しかし、失敗に気づかずマージされてしまった

今後の対策：
1. ✅ PR マージ前に必ずCI/CDの結果を確認
2. ✅ GitHub設定で「Require status checks to pass before merging」を有効化
3. ✅ ローカルでも `set -euo pipefail` でテスト実行

## マージ優先度

🚨 **CRITICAL - 最優先でマージしてください**

理由：
- mainブランチが壊れている（全ビルド失敗）
- PR #39もこの修正がないとマージできない
- 他の開発作業がブロックされている

## マージ順序

### オプション1（推奨）：本PRを先にマージ
1. ✅ **本HOTFIX PRをマージ** ← mainブランチ修正
2. ✅ PR #39をリベース ← 最新のmainを取り込む
3. ✅ PR #39をマージ ← VI有効化

### オプション2：両方同時にマージ
1. ✅ 本HOTFIX PRをマージ
2. ✅ PR #39をそのままマージ（既に同じ修正済み）

## チェックリスト

- [x] SCRIPT_DIR変数を定義
- [x] ローカルで動作確認
- [ ] CI/CDビルド通過確認
- [ ] mainブランチにマージ
- [ ] PR #39の状態確認

## 関連

- **PR #38**: ✅ マージ済み（バグ混入）
- **PR #39**: 🔜 VI有効化（同じ修正を適用済み）
- **Issue**: なし（緊急修正のため直接PR作成）

## 謝罪

PR #38マージ時にCI失敗を見逃してしまい、mainブランチを壊してしまいました。申し訳ございません。今後はCI/CDの結果を必ず確認してからマージします。