### PR TITLE
✨ Discord通知を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,47 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
+
+  notify:
+    name: Discord Notification
+    runs-on: ubuntu-latest
+    needs: [shellcheck, build-and-test, security-scan]
+    if: always()
+    steps:
+      - name: Send success notification
+        if: ${{ needs.shellcheck.result == 'success' && needs.build-and-test.result == 'success' && needs.security-scan.result == 'success' }}
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: 'success'
+          title: '✅ CI/CD Success'
+          description: |
+            **Kimigayo OS CI/CD completed successfully**
+
+            • ShellCheck: ✅ Passed
+            • Build & Test: ✅ All variants passed
+            • Security Scan: ✅ No critical issues
+
+            Commit: ${{ github.sha }}
+            Branch: ${{ github.ref_name }}
+          color: 0x00ff00
+          username: 'Kimigayo CI Bot'
+
+      - name: Send failure notification
+        if: ${{ needs.shellcheck.result == 'failure' || needs.build-and-test.result == 'failure' || needs.security-scan.result == 'failure' }}
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: 'failure'
+          title: '❌ CI/CD Failed'
+          description: |
+            **Kimigayo OS CI/CD failed**
+
+            • ShellCheck: ${{ needs.shellcheck.result == 'success' && '✅' || '❌' }}
+            • Build & Test: ${{ needs.build-and-test.result == 'success' && '✅' || '❌' }}
+            • Security Scan: ${{ needs.security-scan.result == 'success' && '✅' || '❌' }}
+
+            Commit: ${{ github.sha }}
+            Branch: ${{ github.ref_name }}
+          color: 0xff0000
+          username: 'Kimigayo CI Bot'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,3 +420,58 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify:
+    name: Discord Notification
+    runs-on: ubuntu-latest
+    needs: [build-and-push, create-manifest, create-github-release]
+    if: always()
+    steps:
+      - name: Extract version
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="manual-trigger"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Send success notification
+        if: ${{ needs.build-and-push.result == 'success' && needs.create-manifest.result == 'success' && needs.create-github-release.result == 'success' }}
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: 'success'
+          title: '🎉 Release Success'
+          description: |
+            **Kimigayo OS ${{ steps.version.outputs.version }} Released**
+
+            • Build & Push: ✅ All variants built
+            • Manifests: ✅ Multi-arch created
+            • GitHub Release: ✅ Published
+            • Docker Hub: ✅ Images pushed
+
+            🐳 Docker: `docker pull ishinokazuki/kimigayo-os:latest`
+            📦 Release: https://github.com/Kazuki-0731/Kimigayo/releases/tag/${{ steps.version.outputs.version }}
+          color: 0x00ff00
+          username: 'Kimigayo Release Bot'
+
+      - name: Send failure notification
+        if: ${{ needs.build-and-push.result == 'failure' || needs.create-manifest.result == 'failure' || needs.create-github-release.result == 'failure' }}
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: 'failure'
+          title: '❌ Release Failed'
+          description: |
+            **Kimigayo OS ${{ steps.version.outputs.version }} Release Failed**
+
+            • Build & Push: ${{ needs.build-and-push.result == 'success' && '✅' || '❌' }}
+            • Manifests: ${{ needs.create-manifest.result == 'success' && '✅' || '❌' }}
+            • GitHub Release: ${{ needs.create-github-release.result == 'success' && '✅' || '❌' }}
+
+            Tag: ${{ steps.version.outputs.version }}
+            Commit: ${{ github.sha }}
+          color: 0xff0000
+          username: 'Kimigayo Release Bot'


### PR DESCRIPTION
## 概要

CI/CDとリリースワークフローにDiscord通知機能を追加しました。

## 変更内容

### ci.yml
- ✅ **成功時通知**: 全てのジョブが成功した時に緑色の通知を送信
  - ShellCheck、Build & Test、Security Scanのステータス
  - コミットハッシュとブランチ名
- ❌ **失敗時通知**: いずれかのジョブが失敗した時に赤色の通知を送信
  - 各ステップの成功/失敗を✅/❌で表示

### release.yml
- 🎉 **成功時通知**: リリースが成功した時に緑色の通知を送信
  - Build & Push、Manifests、GitHub Releaseのステータス
  - Docker HubとGitHub Releaseへのリンク
- ❌ **失敗時通知**: リリースが失敗した時に赤色の通知を送信
  - 各ステップの成功/失敗を✅/❌で表示

## 設定が必要な項目

GitHub Secretsに`DISCORD_WEBHOOK`を設定してください：

1. リポジトリの Settings → Secrets and variables → Actions
2. New repository secret をクリック
3. Name: `DISCORD_WEBHOOK`
4. Secret: Discordのwebhook URL

## 使用するAction

- [sarisia/actions-status-discord@v1](https://github.com/sarisia/actions-status-discord)

## テスト計画

- [ ] DISCORD_WEBHOOK secretを設定
- [ ] CI/CD成功時の通知を確認
- [ ] CI/CD失敗時の通知を確認（オプション）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)