### PR TITLE
🐛 Release: /etc/shadowパーミッションエラーを修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,13 +124,17 @@ jobs:
           mkdir -p output
           cd build/rootfs
           # macOSのリソースフォーク（._*）とその他の不要ファイルを除外
-          tar czf ../../output/kimigayo-${{ matrix.variant }}-${{ steps.meta.outputs.version }}-${{ matrix.arch }}.tar.gz \
+          # sudoを使ってroot権限でtarを作成（/etc/shadowなどの権限制限ファイルにアクセスするため）
+          sudo tar czf ../../output/kimigayo-${{ matrix.variant }}-${{ steps.meta.outputs.version }}-${{ matrix.arch }}.tar.gz \
             --exclude='._*' \
             --exclude='.DS_Store' \
             --exclude='.AppleDouble' \
             --exclude='.LSOverride' \
+            --numeric-owner \
             .
           cd ../..
+          # tarballの所有権を変更
+          sudo chown $(id -u):$(id -g) output/kimigayo-${{ matrix.variant }}-${{ steps.meta.outputs.version }}-${{ matrix.arch }}.tar.gz
 
           # Verify tarball was created and check its contents
           echo "=== Tarball created ==="


### PR DESCRIPTION
## 問題

release.ymlでrootfsをtarアーカイブする際、`/etc/shadow`ファイルのパーミッション不足でエラーが発生していました：

```
tar: ./etc/shadow: Cannot open: Permission denied
tar: Exiting with failure status due to previous errors
Error: Process completed with exit code 2.
```

## 原因

GitHub Actionsのランナーで`tar`コマンドを実行する際、`/etc/shadow`などのroot所有ファイルに対する読み取り権限が不足していました。

ci.ymlでは成功していたのは、Docker Compose経由でroot権限で実行されているためです。

## 修正内容

### 1. sudo tarを使用
root権限でtarを作成し、権限制限ファイルにアクセスできるようにしました。

```bash
sudo tar czf ../../output/kimigayo-${{ matrix.variant }}-${{ steps.meta.outputs.version }}-${{ matrix.arch }}.tar.gz \
  --exclude='._*' \
  --exclude='.DS_Store' \
  --exclude='.AppleDouble' \
  --exclude='.LSOverride' \
  --numeric-owner \
  .
```

### 2. --numeric-ownerオプション追加
UID/GIDを数値で保存することで、移植性を向上させました。

### 3. sudo chownで所有権変更
tarball作成後、現在のユーザーに所有権を戻すことで、後続のステップでアクセス可能にしました。

```bash
sudo chown $(id -u):$(id -g) output/kimigayo-${{ matrix.variant }}-${{ steps.meta.outputs.version }}-${{ matrix.arch }}.tar.gz
```

## 影響範囲

- ✅ release.ymlのみ修正
- ✅ ci.ymlは影響なし（Docker Compose経由で実行されるため）

## テスト

このPRをマージ後、タグを作成してrelease.ymlが正常に動作することを確認してください。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)