### PR TITLE
🔒 GitHub Advanced Security: permissionsブロックを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [shellcheck, build-and-test, security-scan]
     if: always()
+    permissions: {}
     steps:
       - name: Send success notification
         if: ${{ needs.shellcheck.result == 'success' && needs.build-and-test.result == 'success' && needs.security-scan.result == 'success' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,6 +426,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-and-push, create-manifest, create-github-release]
     if: always()
+    permissions: {}
     steps:
       - name: Extract version
         id: version


### PR DESCRIPTION
## 問題

PR #43でgithub-advanced-securityから以下の警告が報告されました：

> ## Workflow does not contain permissions
> 
> Actions job or workflow does not limit the permissions of the GITHUB_TOKEN. Consider setting an explicit permissions block, using the following as a minimal starting point: {}
> 
> [Show more details](https://github.com/Kazuki-0731/Kimigayo/security/code-scanning/28)

## 修正内容

`notify`ジョブに明示的な`permissions: {}`ブロックを追加し、GITHUB_TOKENの権限を最小限に制限しました。

### 変更箇所

#### `.github/workflows/ci.yml`
```yaml
  notify:
    name: Discord Notification
    runs-on: ubuntu-latest
    needs: [shellcheck, build-and-test, security-scan]
    if: always()
    permissions: {}  # 追加
    steps:
```

#### `.github/workflows/release.yml`
```yaml
  notify:
    name: Discord Notification
    runs-on: ubuntu-latest
    needs: [build-and-push, create-manifest, create-github-release]
    if: always()
    permissions: {}  # 追加
    steps:
```

## セキュリティ向上

`permissions: {}`により、`notify`ジョブではGITHUB_TOKENが一切の権限を持たなくなります。

このジョブはDiscord webhookへのHTTP POSTリクエストのみを行うため、GitHub APIへのアクセスは不要です。明示的に権限を制限することで、以下のメリットがあります：

- ✅ **最小権限の原則**: 必要最小限の権限のみを付与
- ✅ **攻撃面の縮小**: トークンが漏洩しても影響を最小化
- ✅ **セキュリティベストプラクティス**: GitHub Advanced Securityの推奨に準拠

## 影響範囲

- ✅ 既存の機能に影響なし（notifyジョブはGITHUB_TOKENを使用していない）
- ✅ CI/CDの動作は変更なし
- ✅ セキュリティのみ向上

## 参考

- [GitHub Actions: Permissions for GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
- [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-permissions)

## 関連

Closes #43 (github-advanced-securityの警告)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)