### PR TITLE
🐛 Release: artifactダウンロードをkimigayo-*に限定

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,6 +330,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           path: artifacts/
+          pattern: kimigayo-*
 
       - name: Prepare release assets
         run: |


### PR DESCRIPTION
## 問題

v1.0.0タグのrelease.ymlでartifactダウンロード時に、全てのartifactをダウンロードしようとして失敗しました：

```
Error: Unable to download artifact(s): Unable to download and extract artifact: 
Artifact download failed after 5 retries.
```

### 詳細

- 12個のartifactが見つかりました：
  - 6個の`kimigayo-*.tar.gz`ファイル（必要）✅
  - 6個の`.dockerbuild`ファイル（不要）❌
- 6個のtarballダウンロードは成功
- 6個のdockerbuildファイルダウンロードが5回リトライ後に失敗

## 原因

`build-and-push`ジョブがDockerビルドキャッシュ（`.dockerbuild`）もartifactとしてアップロードしていますが、リリース作成時には不要です。

`actions/download-artifact@v7`にパターンフィルタを指定せずに全artifactをダウンロードしようとしたため、不要なファイルもダウンロード対象になりました。

## 修正内容

`pattern: kimigayo-*`を追加して、rootfs tarballだけをダウンロードするように修正：

```yaml
- name: Download all artifacts
  uses: actions/download-artifact@v7
  with:
    path: artifacts/
    pattern: kimigayo-*  # ← 追加
```

これにより：
- `kimigayo-minimal-1.0.0-x86_64` ✅
- `kimigayo-minimal-1.0.0-arm64` ✅
- `kimigayo-standard-1.0.0-x86_64` ✅
- `kimigayo-standard-1.0.0-arm64` ✅
- `kimigayo-extended-1.0.0-x86_64` ✅
- `kimigayo-extended-1.0.0-arm64` ✅

だけがダウンロードされます。

## 影響範囲

- ✅ リリース作成時のartifactダウンロードが高速化
- ✅ 不要なダウンロードエラーを回避
- ✅ 必要なファイルだけを確実にダウンロード
- ✅ CI/CDには影響なし

## テスト

このPRマージ後、v1.0.0タグを再作成してrelease.ymlが正常に動作することを確認してください。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)