### PR TITLE
✨ リリースノートに前回タグからのPRリスト自動生成を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,7 +341,18 @@ jobs:
       - name: Generate release notes
         id: release_notes
         run: |
-          cat > release-notes.md <<'EOF'
+          # Get previous tag
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -2 | tail -1)
+
+          if [ -z "$PREVIOUS_TAG" ]; then
+            echo "No previous tag found, this is the first release"
+            PREVIOUS_TAG="HEAD~100"
+          fi
+
+          echo "Generating release notes from ${PREVIOUS_TAG} to v${{ steps.version.outputs.version }}"
+
+          # Generate PR list
+          cat > release-notes.md <<EOF
           # Kimigayo OS v${{ steps.version.outputs.version }}
 
           ## 🎉 Release Highlights
@@ -351,32 +362,57 @@ jobs:
           ## 📦 Available Images
 
           ### Standard Variant (Recommended)
-          ```bash
-          docker pull ishinokazuki/kimigayo-os:${{ steps.version.outputs.version }}
-          docker pull ishinokazuki/kimigayo-os:latest
-          ```
+          \`\`\`bash
+          docker pull ishinokazuki/kimigayo-os:${{ steps.version.outputs.version }}-standard
+          docker pull ishinokazuki/kimigayo-os:latest-standard
+          \`\`\`
 
           ### Minimal Variant
-          ```bash
+          \`\`\`bash
           docker pull ishinokazuki/kimigayo-os:${{ steps.version.outputs.version }}-minimal
           docker pull ishinokazuki/kimigayo-os:latest-minimal
-          ```
+          \`\`\`
 
           ### Extended Variant
-          ```bash
+          \`\`\`bash
           docker pull ishinokazuki/kimigayo-os:${{ steps.version.outputs.version }}-extended
           docker pull ishinokazuki/kimigayo-os:latest-extended
-          ```
+          \`\`\`
+
+          ## 🔄 Changes Since ${PREVIOUS_TAG}
+
+          ### Pull Requests
+          EOF
+
+          # Extract PR numbers from commit messages and generate PR list
+          git log ${PREVIOUS_TAG}..HEAD --oneline --grep='Merge pull request' | \
+            sed -n 's/.*Merge pull request #\([0-9]*\).*/\1/p' | \
+            sort -rn | uniq | while read pr; do
+              PR_TITLE=$(gh pr view $pr --json title --jq '.title' 2>/dev/null || echo "PR #$pr")
+              echo "- #$pr: ${PR_TITLE}" >> release-notes.md
+            done
+
+          # Add commit summary if no PRs found
+          PR_COUNT=$(git log ${PREVIOUS_TAG}..HEAD --oneline --grep='Merge pull request' | wc -l)
+          if [ "$PR_COUNT" -eq 0 ]; then
+            echo "" >> release-notes.md
+            echo "### Commits" >> release-notes.md
+            git log ${PREVIOUS_TAG}..HEAD --oneline --pretty=format:"- %s (%h)" >> release-notes.md
+            echo "" >> release-notes.md
+          fi
+
+          # Continue with rest of release notes
+          cat >> release-notes.md <<EOF
 
           ## 🏗️ Build Artifacts
 
           This release includes pre-built rootfs tarballs for all variants and architectures:
-          - `kimigayo-minimal-${{ steps.version.outputs.version }}-x86_64.tar.gz`
-          - `kimigayo-minimal-${{ steps.version.outputs.version }}-arm64.tar.gz`
-          - `kimigayo-standard-${{ steps.version.outputs.version }}-x86_64.tar.gz`
-          - `kimigayo-standard-${{ steps.version.outputs.version }}-arm64.tar.gz`
-          - `kimigayo-extended-${{ steps.version.outputs.version }}-x86_64.tar.gz`
-          - `kimigayo-extended-${{ steps.version.outputs.version }}-arm64.tar.gz`
+          - \`kimigayo-minimal-${{ steps.version.outputs.version }}-x86_64.tar.gz\`
+          - \`kimigayo-minimal-${{ steps.version.outputs.version }}-arm64.tar.gz\`
+          - \`kimigayo-standard-${{ steps.version.outputs.version }}-x86_64.tar.gz\`
+          - \`kimigayo-standard-${{ steps.version.outputs.version }}-arm64.tar.gz\`
+          - \`kimigayo-extended-${{ steps.version.outputs.version }}-x86_64.tar.gz\`
+          - \`kimigayo-extended-${{ steps.version.outputs.version }}-arm64.tar.gz\`
 
           ## 🔒 Security
 


### PR DESCRIPTION
## 📋 概要

リリースノートに前回のタグからの変更内容（PRリスト）を自動生成する機能を追加します。

## 🎯 目的

リリース時に手動でPRリストを書く必要がなく、自動的に前回のタグからの差分を生成します。

## ✨ 機能

### 1. 前回タグの自動検出
```bash
PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -2 | tail -1)
```
- バージョンタグ（v1.0.0形式）のみを対象
- 最新から2番目のタグを前回タグとして使用

### 2. PRリストの自動生成
```bash
git log ${PREVIOUS_TAG}..HEAD --oneline --grep='Merge pull request' | \
  sed -n 's/.*Merge pull request #\([0-9]*\).*/\1/p' | \
  sort -rn | uniq | while read pr; do
    PR_TITLE=$(gh pr view $pr --json title --jq '.title' 2>/dev/null || echo "PR #$pr")
    echo "- #$pr: ${PR_TITLE}"
  done
```
- git logからマージコミットを抽出
- PR番号を取得
- gh CLIでPRタイトルを取得
- 降順でリスト化

### 3. フォールバック機能
PRが見つからない場合は、コミットリストを表示：
```bash
git log ${PREVIOUS_TAG}..HEAD --oneline --pretty=format:"- %s (%h)"
```

## 📝 リリースノート例

```markdown
## 🔄 Changes Since v0.9.0

### Pull Requests
- #47: 🔧 Docker Hubタグ命名規則を統一
- #46: 🐛 アーティファクトダウンロードパターンフィルタを追加
- #45: 🔒 GitHub Advanced Security警告を修正
- #44: 🐛 Release: /etc/shadowパーミッションエラー修正
```

## 🔧 その他の変更

- Docker pull例を新しい命名規則（`-standard`, `-minimal`, `-extended`サフィックス）に更新

## 🧪 テスト

次回のリリース（v1.0.1など）で自動生成されるリリースノートを確認できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)